### PR TITLE
Expand metrics scope

### DIFF
--- a/deconz.py
+++ b/deconz.py
@@ -6,12 +6,18 @@ _gauges = {
   "humidity": Gauge("deconz_sensor_humidity", "Humidity of sensor in percent", ["manufacturer", "model", "name", "type", "uid"]),
   "pressure": Gauge("deconz_sensor_pressure", "Air pressure in hectopascal (hPa)", ["manufacturer", "model", "name", "type", "uid"]),
   "temperature": Gauge("deconz_sensor_temperature", "Temperature of sensor in Celsius", ["manufacturer", "model", "name", "type", "uid"]),
+  "open": Gauge("deconz_sensor_contact", "Contact Sensor", ["manufacturer", "model", "name", "type", "uid"]),
+  "presence": Gauge("deconz_sensor_motion", "Motion Sensor", ["manufacturer", "model", "name", "type", "uid"]),
+  "lux": Gauge("deconz_sensor_lux", "Light Sensor", ["manufacturer", "model", "name", "type", "uid"]),
 };
 
 _functionMap = {
   'ZHAHumidity': lambda x: _extract_basic_metric(x, 'humidity', 100),
   'ZHATemperature': lambda x: _extract_basic_metric(x, 'temperature', 100),
   'ZHAPressure': lambda x: _extract_basic_metric(x, 'pressure', 1),
+  'ZHAOpenClose': lambda x: _extract_basic_metric(x, 'open', 1),
+  'ZHAPresence': lambda x: _extract_basic_metric(x, 'presence', 1),
+  'ZHALightLevel': lambda x: _extract_basic_metric(x, 'lux', 1),
 };
 
 
@@ -36,7 +42,7 @@ def extract_metrics(logger, request_content):
     if metric['type'] in _functionMap:
       _functionMap[metric['type']](metric);
     else:
-      logger.info(f"Unknow metric type \"{metric['type']}\".");
+      logger.info(f"Unknown metric type \"{metric['type']}\".");
 
 def _extract_battery(data):
   processed = set();


### PR DESCRIPTION
I'm pretty new to GitHub and an amateur coder at best so hopefully I've done this right to contribute back to your original code 🙂

I've added some lines to the array to include support for contact, motion and light level sensors. This has been tested and is working with the Hue Motion sensor and the Sonoff contact sensors. ZHAOpenClose and ZHAPresence are both bool types in the API but with the existing value extractor, these just get converted to a 1 or 0 result respectively.

Hope the changes are okay. Will your docker image auto build or is something needed to update it?